### PR TITLE
Use multi-stage builds

### DIFF
--- a/10-to-11/Dockerfile
+++ b/10-to-11/Dockerfile
@@ -1,10 +1,7 @@
 FROM postgres:11
 
-RUN sed -i 's/$/ 10/' /etc/apt/sources.list.d/pgdg.list
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		postgresql-10=10.6-1.pgdg90+1 \
-	&& rm -rf /var/lib/apt/lists/*
+COPY --from=postgres:10 /usr/lib/postgresql/10 /usr/lib/postgresql/10/
+COPY --from=postgres:10 /usr/share/postgresql/10 /usr/share/postgresql/10/
 
 ENV PGBINOLD /usr/lib/postgresql/10/bin
 ENV PGBINNEW /usr/lib/postgresql/11/bin


### PR DESCRIPTION
#### Notes:

+ No need to mess up with `apt` and its sources/repos.
+ Broaden hardware arch support (e.g. used this to build on a Raspberry Pi).
  - Apt repos seem to miss binaries compiled for some archs.
+ WIP: If direction acceptable, we might use this approach for all the image variants e.g. `9.6-to-11`.

#### References:

+ Docker docs on multi-stage builds: https://docs.docker.com/develop/develop-images/multistage-build/