### PR TITLE
add password to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ $ NEW='9.5'
 $ docker pull "postgres:$OLD"
 $ docker run -dit \
 	--name postgres-upgrade-testing \
+	-e POSTGRES_PASSWORD=password \
 	-v "$PWD/$OLD/data":/var/lib/postgresql/data \
 	"postgres:$OLD"
 $ sleep 5
@@ -99,6 +100,7 @@ $ docker run --rm \
 $ docker pull "postgres:$NEW"
 $ docker run -dit \
 	--name postgres-upgrade-testing \
+	-e POSTGRES_PASSWORD=password \
 	-v "$PWD/$NEW/data":/var/lib/postgresql/data \
 	"postgres:$NEW"
 $ sleep 5


### PR DESCRIPTION
If `POSTGRES_PASSWORD` is not specified, postgres will simply not run, and will return this error:

```
Error: Database is uninitialized and superuser password is not specified.
       You must specify POSTGRES_PASSWORD for the superuser. Use
       "-e POSTGRES_PASSWORD=password" to set it in "docker run".
```