### PR TITLE
Use bookworm as base where available

### DIFF
--- a/10-to-11/Dockerfile
+++ b/10-to-11/Dockerfile
@@ -1,9 +1,9 @@
-FROM postgres:11-bullseye
+FROM postgres:11-bookworm
 
 RUN sed -i 's/$/ 10/' /etc/apt/sources.list.d/pgdg.list
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-		postgresql-10=10.23-2.pgdg110+1 \
+		postgresql-10=10.23-2.pgdg120+1 \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV PGBINOLD /usr/lib/postgresql/10/bin

--- a/10-to-12/Dockerfile
+++ b/10-to-12/Dockerfile
@@ -1,9 +1,9 @@
-FROM postgres:12-bullseye
+FROM postgres:12-bookworm
 
 RUN sed -i 's/$/ 10/' /etc/apt/sources.list.d/pgdg.list
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-		postgresql-10=10.23-2.pgdg110+1 \
+		postgresql-10=10.23-2.pgdg120+1 \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV PGBINOLD /usr/lib/postgresql/10/bin

--- a/10-to-13/Dockerfile
+++ b/10-to-13/Dockerfile
@@ -1,9 +1,9 @@
-FROM postgres:13-bullseye
+FROM postgres:13-bookworm
 
 RUN sed -i 's/$/ 10/' /etc/apt/sources.list.d/pgdg.list
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-		postgresql-10=10.23-2.pgdg110+1 \
+		postgresql-10=10.23-2.pgdg120+1 \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV PGBINOLD /usr/lib/postgresql/10/bin

--- a/10-to-14/Dockerfile
+++ b/10-to-14/Dockerfile
@@ -1,9 +1,9 @@
-FROM postgres:14-bullseye
+FROM postgres:14-bookworm
 
 RUN sed -i 's/$/ 10/' /etc/apt/sources.list.d/pgdg.list
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-		postgresql-10=10.23-2.pgdg110+1 \
+		postgresql-10=10.23-2.pgdg120+1 \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV PGBINOLD /usr/lib/postgresql/10/bin

--- a/10-to-15/Dockerfile
+++ b/10-to-15/Dockerfile
@@ -1,9 +1,9 @@
-FROM postgres:15-bullseye
+FROM postgres:15-bookworm
 
 RUN sed -i 's/$/ 10/' /etc/apt/sources.list.d/pgdg.list
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-		postgresql-10=10.23-2.pgdg110+1 \
+		postgresql-10=10.23-2.pgdg120+1 \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV PGBINOLD /usr/lib/postgresql/10/bin

--- a/11-to-12/Dockerfile
+++ b/11-to-12/Dockerfile
@@ -1,9 +1,9 @@
-FROM postgres:12-bullseye
+FROM postgres:12-bookworm
 
 RUN sed -i 's/$/ 11/' /etc/apt/sources.list.d/pgdg.list
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-		postgresql-11=11.21-1.pgdg110+1 \
+		postgresql-11=11.21-1.pgdg120+1 \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV PGBINOLD /usr/lib/postgresql/11/bin

--- a/11-to-13/Dockerfile
+++ b/11-to-13/Dockerfile
@@ -1,9 +1,9 @@
-FROM postgres:13-bullseye
+FROM postgres:13-bookworm
 
 RUN sed -i 's/$/ 11/' /etc/apt/sources.list.d/pgdg.list
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-		postgresql-11=11.21-1.pgdg110+1 \
+		postgresql-11=11.21-1.pgdg120+1 \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV PGBINOLD /usr/lib/postgresql/11/bin

--- a/11-to-14/Dockerfile
+++ b/11-to-14/Dockerfile
@@ -1,9 +1,9 @@
-FROM postgres:14-bullseye
+FROM postgres:14-bookworm
 
 RUN sed -i 's/$/ 11/' /etc/apt/sources.list.d/pgdg.list
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-		postgresql-11=11.21-1.pgdg110+1 \
+		postgresql-11=11.21-1.pgdg120+1 \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV PGBINOLD /usr/lib/postgresql/11/bin

--- a/11-to-15/Dockerfile
+++ b/11-to-15/Dockerfile
@@ -1,9 +1,9 @@
-FROM postgres:15-bullseye
+FROM postgres:15-bookworm
 
 RUN sed -i 's/$/ 11/' /etc/apt/sources.list.d/pgdg.list
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-		postgresql-11=11.21-1.pgdg110+1 \
+		postgresql-11=11.21-1.pgdg120+1 \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV PGBINOLD /usr/lib/postgresql/11/bin

--- a/12-to-13/Dockerfile
+++ b/12-to-13/Dockerfile
@@ -1,9 +1,9 @@
-FROM postgres:13-bullseye
+FROM postgres:13-bookworm
 
 RUN sed -i 's/$/ 12/' /etc/apt/sources.list.d/pgdg.list
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-		postgresql-12=12.16-1.pgdg110+1 \
+		postgresql-12=12.16-1.pgdg120+1 \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV PGBINOLD /usr/lib/postgresql/12/bin

--- a/12-to-14/Dockerfile
+++ b/12-to-14/Dockerfile
@@ -1,9 +1,9 @@
-FROM postgres:14-bullseye
+FROM postgres:14-bookworm
 
 RUN sed -i 's/$/ 12/' /etc/apt/sources.list.d/pgdg.list
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-		postgresql-12=12.16-1.pgdg110+1 \
+		postgresql-12=12.16-1.pgdg120+1 \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV PGBINOLD /usr/lib/postgresql/12/bin

--- a/12-to-15/Dockerfile
+++ b/12-to-15/Dockerfile
@@ -1,9 +1,9 @@
-FROM postgres:15-bullseye
+FROM postgres:15-bookworm
 
 RUN sed -i 's/$/ 12/' /etc/apt/sources.list.d/pgdg.list
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-		postgresql-12=12.16-1.pgdg110+1 \
+		postgresql-12=12.16-1.pgdg120+1 \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV PGBINOLD /usr/lib/postgresql/12/bin

--- a/13-to-14/Dockerfile
+++ b/13-to-14/Dockerfile
@@ -1,9 +1,9 @@
-FROM postgres:14-bullseye
+FROM postgres:14-bookworm
 
 RUN sed -i 's/$/ 13/' /etc/apt/sources.list.d/pgdg.list
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-		postgresql-13=13.12-1.pgdg110+1 \
+		postgresql-13=13.12-1.pgdg120+1 \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV PGBINOLD /usr/lib/postgresql/13/bin

--- a/13-to-15/Dockerfile
+++ b/13-to-15/Dockerfile
@@ -1,9 +1,9 @@
-FROM postgres:15-bullseye
+FROM postgres:15-bookworm
 
 RUN sed -i 's/$/ 13/' /etc/apt/sources.list.d/pgdg.list
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-		postgresql-13=13.12-1.pgdg110+1 \
+		postgresql-13=13.12-1.pgdg120+1 \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV PGBINOLD /usr/lib/postgresql/13/bin

--- a/14-to-15/Dockerfile
+++ b/14-to-15/Dockerfile
@@ -1,9 +1,9 @@
-FROM postgres:15-bullseye
+FROM postgres:15-bookworm
 
 RUN sed -i 's/$/ 14/' /etc/apt/sources.list.d/pgdg.list
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-		postgresql-14=14.9-1.pgdg110+1 \
+		postgresql-14=14.9-1.pgdg120+1 \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV PGBINOLD /usr/lib/postgresql/14/bin

--- a/9.6-to-11/Dockerfile
+++ b/9.6-to-11/Dockerfile
@@ -1,10 +1,10 @@
-FROM postgres:11-bullseye
+FROM postgres:11-bookworm
 
 RUN sed -i 's/$/ 9.6/' /etc/apt/sources.list.d/pgdg.list
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-		postgresql-9.6=9.6.24-5.pgdg110+1 \
-		postgresql-contrib-9.6=9.6.24-5.pgdg110+1 \
+		postgresql-9.6=9.6.24-5.pgdg120+1 \
+		postgresql-contrib-9.6=9.6.24-5.pgdg120+1 \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV PGBINOLD /usr/lib/postgresql/9.6/bin

--- a/9.6-to-12/Dockerfile
+++ b/9.6-to-12/Dockerfile
@@ -1,10 +1,10 @@
-FROM postgres:12-bullseye
+FROM postgres:12-bookworm
 
 RUN sed -i 's/$/ 9.6/' /etc/apt/sources.list.d/pgdg.list
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-		postgresql-9.6=9.6.24-5.pgdg110+1 \
-		postgresql-contrib-9.6=9.6.24-5.pgdg110+1 \
+		postgresql-9.6=9.6.24-5.pgdg120+1 \
+		postgresql-contrib-9.6=9.6.24-5.pgdg120+1 \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV PGBINOLD /usr/lib/postgresql/9.6/bin

--- a/9.6-to-13/Dockerfile
+++ b/9.6-to-13/Dockerfile
@@ -1,10 +1,10 @@
-FROM postgres:13-bullseye
+FROM postgres:13-bookworm
 
 RUN sed -i 's/$/ 9.6/' /etc/apt/sources.list.d/pgdg.list
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-		postgresql-9.6=9.6.24-5.pgdg110+1 \
-		postgresql-contrib-9.6=9.6.24-5.pgdg110+1 \
+		postgresql-9.6=9.6.24-5.pgdg120+1 \
+		postgresql-contrib-9.6=9.6.24-5.pgdg120+1 \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV PGBINOLD /usr/lib/postgresql/9.6/bin

--- a/9.6-to-14/Dockerfile
+++ b/9.6-to-14/Dockerfile
@@ -1,10 +1,10 @@
-FROM postgres:14-bullseye
+FROM postgres:14-bookworm
 
 RUN sed -i 's/$/ 9.6/' /etc/apt/sources.list.d/pgdg.list
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-		postgresql-9.6=9.6.24-5.pgdg110+1 \
-		postgresql-contrib-9.6=9.6.24-5.pgdg110+1 \
+		postgresql-9.6=9.6.24-5.pgdg120+1 \
+		postgresql-contrib-9.6=9.6.24-5.pgdg120+1 \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV PGBINOLD /usr/lib/postgresql/9.6/bin

--- a/9.6-to-15/Dockerfile
+++ b/9.6-to-15/Dockerfile
@@ -1,10 +1,10 @@
-FROM postgres:15-bullseye
+FROM postgres:15-bookworm
 
 RUN sed -i 's/$/ 9.6/' /etc/apt/sources.list.d/pgdg.list
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-		postgresql-9.6=9.6.24-5.pgdg110+1 \
-		postgresql-contrib-9.6=9.6.24-5.pgdg110+1 \
+		postgresql-9.6=9.6.24-5.pgdg120+1 \
+		postgresql-contrib-9.6=9.6.24-5.pgdg120+1 \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV PGBINOLD /usr/lib/postgresql/9.6/bin

--- a/update.sh
+++ b/update.sh
@@ -47,7 +47,7 @@ for i in "${!supportedVersions[@]}"; do
 			> "$dir/Dockerfile"
 		cp docker-upgrade "$dir/"
 		if [[ "$old" != 9.* ]]; then
-			sed -i '/postgresql-contrib-/d' "$dir/Dockerfile"
+			sed -i -e '/postgresql-contrib-/d' "$dir/Dockerfile"
 		fi
 	done
 done

--- a/update.sh
+++ b/update.sh
@@ -15,7 +15,7 @@ supportedVersions=(
 	#9.3
 	#9.2
 )
-suite='bullseye'
+suite='bookworm'
 
 for i in "${!supportedVersions[@]}"; do
 	new="${supportedVersions[$i]}"


### PR DESCRIPTION
`bookworm` variants [have been added for 10 and newer](https://github.com/docker-library/postgres/commit/3fda89cc5c2e588f46ae4f1ac117114c8e6814f1) and are the default for 12 and newer so use them where available