### PR TITLE
add locales

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -4,7 +4,7 @@ RUN sed -i 's/$/ {{ .old }}/' /etc/apt/sources.list.d/pgdg.list
 
 RUN set -eux; \
 	apt-get update; \
-	apt-get install -y --no-install-recommends \
+	apt-get install -y --no-install-recommends locales locales-all \
 		postgresql-{{ .old }}={{ .version | @sh }} \
 	; \
 	rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
avoid 
```
The database was initialized with LC_COLLATE "XXX",  which is not recognized by setlocale()
```