### PR TITLE
feat(suites): add alpine dockerfiles

### DIFF
--- a/12-to-13/Dockerfile.alpine
+++ b/12-to-13/Dockerfile.alpine
@@ -1,0 +1,29 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM postgres:13-alpine
+
+RUN set -eux; \
+	apk add --no-cache postgresql12
+
+ENV PGBINOLD /usr/libexec/postgresql12
+ENV PGBINNEW /usr/local/bin
+
+ENV PGDATAOLD /var/lib/postgresql/12/data
+ENV PGDATANEW /var/lib/postgresql/13/data
+
+RUN set -eux; \
+	mkdir -p "$PGDATAOLD" "$PGDATANEW"; \
+	chown -R postgres:postgres /var/lib/postgresql
+
+WORKDIR /var/lib/postgresql
+
+COPY docker-upgrade /usr/local/bin/
+
+ENTRYPOINT ["docker-upgrade"]
+
+# recommended: --link
+CMD ["pg_upgrade"]

--- a/12-to-14/Dockerfile.alpine
+++ b/12-to-14/Dockerfile.alpine
@@ -1,0 +1,29 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM postgres:14-alpine
+
+RUN set -eux; \
+	apk add --no-cache postgresql12
+
+ENV PGBINOLD /usr/libexec/postgresql12
+ENV PGBINNEW /usr/local/bin
+
+ENV PGDATAOLD /var/lib/postgresql/12/data
+ENV PGDATANEW /var/lib/postgresql/14/data
+
+RUN set -eux; \
+	mkdir -p "$PGDATAOLD" "$PGDATANEW"; \
+	chown -R postgres:postgres /var/lib/postgresql
+
+WORKDIR /var/lib/postgresql
+
+COPY docker-upgrade /usr/local/bin/
+
+ENTRYPOINT ["docker-upgrade"]
+
+# recommended: --link
+CMD ["pg_upgrade"]

--- a/12-to-15/Dockerfile.alpine
+++ b/12-to-15/Dockerfile.alpine
@@ -1,0 +1,29 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM postgres:15-alpine
+
+RUN set -eux; \
+	apk add --no-cache postgresql12
+
+ENV PGBINOLD /usr/libexec/postgresql12
+ENV PGBINNEW /usr/local/bin
+
+ENV PGDATAOLD /var/lib/postgresql/12/data
+ENV PGDATANEW /var/lib/postgresql/15/data
+
+RUN set -eux; \
+	mkdir -p "$PGDATAOLD" "$PGDATANEW"; \
+	chown -R postgres:postgres /var/lib/postgresql
+
+WORKDIR /var/lib/postgresql
+
+COPY docker-upgrade /usr/local/bin/
+
+ENTRYPOINT ["docker-upgrade"]
+
+# recommended: --link
+CMD ["pg_upgrade"]

--- a/12-to-16/Dockerfile.alpine
+++ b/12-to-16/Dockerfile.alpine
@@ -1,0 +1,29 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM postgres:16-alpine
+
+RUN set -eux; \
+	apk add --no-cache postgresql12
+
+ENV PGBINOLD /usr/libexec/postgresql12
+ENV PGBINNEW /usr/local/bin
+
+ENV PGDATAOLD /var/lib/postgresql/12/data
+ENV PGDATANEW /var/lib/postgresql/16/data
+
+RUN set -eux; \
+	mkdir -p "$PGDATAOLD" "$PGDATANEW"; \
+	chown -R postgres:postgres /var/lib/postgresql
+
+WORKDIR /var/lib/postgresql
+
+COPY docker-upgrade /usr/local/bin/
+
+ENTRYPOINT ["docker-upgrade"]
+
+# recommended: --link
+CMD ["pg_upgrade"]

--- a/12-to-17/Dockerfile.alpine
+++ b/12-to-17/Dockerfile.alpine
@@ -1,0 +1,29 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM postgres:17-alpine
+
+RUN set -eux; \
+	apk add --no-cache postgresql12
+
+ENV PGBINOLD /usr/libexec/postgresql12
+ENV PGBINNEW /usr/local/bin
+
+ENV PGDATAOLD /var/lib/postgresql/12/data
+ENV PGDATANEW /var/lib/postgresql/17/data
+
+RUN set -eux; \
+	mkdir -p "$PGDATAOLD" "$PGDATANEW"; \
+	chown -R postgres:postgres /var/lib/postgresql
+
+WORKDIR /var/lib/postgresql
+
+COPY docker-upgrade /usr/local/bin/
+
+ENTRYPOINT ["docker-upgrade"]
+
+# recommended: --link
+CMD ["pg_upgrade"]

--- a/13-to-14/Dockerfile.alpine
+++ b/13-to-14/Dockerfile.alpine
@@ -1,0 +1,29 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM postgres:14-alpine
+
+RUN set -eux; \
+	apk add --no-cache postgresql13
+
+ENV PGBINOLD /usr/libexec/postgresql13
+ENV PGBINNEW /usr/local/bin
+
+ENV PGDATAOLD /var/lib/postgresql/13/data
+ENV PGDATANEW /var/lib/postgresql/14/data
+
+RUN set -eux; \
+	mkdir -p "$PGDATAOLD" "$PGDATANEW"; \
+	chown -R postgres:postgres /var/lib/postgresql
+
+WORKDIR /var/lib/postgresql
+
+COPY docker-upgrade /usr/local/bin/
+
+ENTRYPOINT ["docker-upgrade"]
+
+# recommended: --link
+CMD ["pg_upgrade"]

--- a/13-to-15/Dockerfile.alpine
+++ b/13-to-15/Dockerfile.alpine
@@ -1,0 +1,29 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM postgres:15-alpine
+
+RUN set -eux; \
+	apk add --no-cache postgresql13
+
+ENV PGBINOLD /usr/libexec/postgresql13
+ENV PGBINNEW /usr/local/bin
+
+ENV PGDATAOLD /var/lib/postgresql/13/data
+ENV PGDATANEW /var/lib/postgresql/15/data
+
+RUN set -eux; \
+	mkdir -p "$PGDATAOLD" "$PGDATANEW"; \
+	chown -R postgres:postgres /var/lib/postgresql
+
+WORKDIR /var/lib/postgresql
+
+COPY docker-upgrade /usr/local/bin/
+
+ENTRYPOINT ["docker-upgrade"]
+
+# recommended: --link
+CMD ["pg_upgrade"]

--- a/13-to-16/Dockerfile.alpine
+++ b/13-to-16/Dockerfile.alpine
@@ -1,0 +1,29 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM postgres:16-alpine
+
+RUN set -eux; \
+	apk add --no-cache postgresql13
+
+ENV PGBINOLD /usr/libexec/postgresql13
+ENV PGBINNEW /usr/local/bin
+
+ENV PGDATAOLD /var/lib/postgresql/13/data
+ENV PGDATANEW /var/lib/postgresql/16/data
+
+RUN set -eux; \
+	mkdir -p "$PGDATAOLD" "$PGDATANEW"; \
+	chown -R postgres:postgres /var/lib/postgresql
+
+WORKDIR /var/lib/postgresql
+
+COPY docker-upgrade /usr/local/bin/
+
+ENTRYPOINT ["docker-upgrade"]
+
+# recommended: --link
+CMD ["pg_upgrade"]

--- a/13-to-17/Dockerfile.alpine
+++ b/13-to-17/Dockerfile.alpine
@@ -1,0 +1,29 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM postgres:17-alpine
+
+RUN set -eux; \
+	apk add --no-cache postgresql13
+
+ENV PGBINOLD /usr/libexec/postgresql13
+ENV PGBINNEW /usr/local/bin
+
+ENV PGDATAOLD /var/lib/postgresql/13/data
+ENV PGDATANEW /var/lib/postgresql/17/data
+
+RUN set -eux; \
+	mkdir -p "$PGDATAOLD" "$PGDATANEW"; \
+	chown -R postgres:postgres /var/lib/postgresql
+
+WORKDIR /var/lib/postgresql
+
+COPY docker-upgrade /usr/local/bin/
+
+ENTRYPOINT ["docker-upgrade"]
+
+# recommended: --link
+CMD ["pg_upgrade"]

--- a/14-to-15/Dockerfile.alpine
+++ b/14-to-15/Dockerfile.alpine
@@ -1,0 +1,29 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM postgres:15-alpine
+
+RUN set -eux; \
+	apk add --no-cache postgresql14
+
+ENV PGBINOLD /usr/libexec/postgresql14
+ENV PGBINNEW /usr/local/bin
+
+ENV PGDATAOLD /var/lib/postgresql/14/data
+ENV PGDATANEW /var/lib/postgresql/15/data
+
+RUN set -eux; \
+	mkdir -p "$PGDATAOLD" "$PGDATANEW"; \
+	chown -R postgres:postgres /var/lib/postgresql
+
+WORKDIR /var/lib/postgresql
+
+COPY docker-upgrade /usr/local/bin/
+
+ENTRYPOINT ["docker-upgrade"]
+
+# recommended: --link
+CMD ["pg_upgrade"]

--- a/14-to-16/Dockerfile.alpine
+++ b/14-to-16/Dockerfile.alpine
@@ -1,0 +1,29 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM postgres:16-alpine
+
+RUN set -eux; \
+	apk add --no-cache postgresql14
+
+ENV PGBINOLD /usr/libexec/postgresql14
+ENV PGBINNEW /usr/local/bin
+
+ENV PGDATAOLD /var/lib/postgresql/14/data
+ENV PGDATANEW /var/lib/postgresql/16/data
+
+RUN set -eux; \
+	mkdir -p "$PGDATAOLD" "$PGDATANEW"; \
+	chown -R postgres:postgres /var/lib/postgresql
+
+WORKDIR /var/lib/postgresql
+
+COPY docker-upgrade /usr/local/bin/
+
+ENTRYPOINT ["docker-upgrade"]
+
+# recommended: --link
+CMD ["pg_upgrade"]

--- a/14-to-17/Dockerfile.alpine
+++ b/14-to-17/Dockerfile.alpine
@@ -1,0 +1,29 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM postgres:17-alpine
+
+RUN set -eux; \
+	apk add --no-cache postgresql14
+
+ENV PGBINOLD /usr/libexec/postgresql14
+ENV PGBINNEW /usr/local/bin
+
+ENV PGDATAOLD /var/lib/postgresql/14/data
+ENV PGDATANEW /var/lib/postgresql/17/data
+
+RUN set -eux; \
+	mkdir -p "$PGDATAOLD" "$PGDATANEW"; \
+	chown -R postgres:postgres /var/lib/postgresql
+
+WORKDIR /var/lib/postgresql
+
+COPY docker-upgrade /usr/local/bin/
+
+ENTRYPOINT ["docker-upgrade"]
+
+# recommended: --link
+CMD ["pg_upgrade"]

--- a/15-to-16/Dockerfile.alpine
+++ b/15-to-16/Dockerfile.alpine
@@ -1,0 +1,29 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM postgres:16-alpine
+
+RUN set -eux; \
+	apk add --no-cache postgresql15
+
+ENV PGBINOLD /usr/libexec/postgresql15
+ENV PGBINNEW /usr/local/bin
+
+ENV PGDATAOLD /var/lib/postgresql/15/data
+ENV PGDATANEW /var/lib/postgresql/16/data
+
+RUN set -eux; \
+	mkdir -p "$PGDATAOLD" "$PGDATANEW"; \
+	chown -R postgres:postgres /var/lib/postgresql
+
+WORKDIR /var/lib/postgresql
+
+COPY docker-upgrade /usr/local/bin/
+
+ENTRYPOINT ["docker-upgrade"]
+
+# recommended: --link
+CMD ["pg_upgrade"]

--- a/15-to-17/Dockerfile.alpine
+++ b/15-to-17/Dockerfile.alpine
@@ -1,0 +1,29 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM postgres:17-alpine
+
+RUN set -eux; \
+	apk add --no-cache postgresql15
+
+ENV PGBINOLD /usr/libexec/postgresql15
+ENV PGBINNEW /usr/local/bin
+
+ENV PGDATAOLD /var/lib/postgresql/15/data
+ENV PGDATANEW /var/lib/postgresql/17/data
+
+RUN set -eux; \
+	mkdir -p "$PGDATAOLD" "$PGDATANEW"; \
+	chown -R postgres:postgres /var/lib/postgresql
+
+WORKDIR /var/lib/postgresql
+
+COPY docker-upgrade /usr/local/bin/
+
+ENTRYPOINT ["docker-upgrade"]
+
+# recommended: --link
+CMD ["pg_upgrade"]

--- a/16-to-17/Dockerfile.alpine
+++ b/16-to-17/Dockerfile.alpine
@@ -1,0 +1,29 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM postgres:17-alpine
+
+RUN set -eux; \
+	apk add --no-cache postgresql16
+
+ENV PGBINOLD /usr/libexec/postgresql16
+ENV PGBINNEW /usr/local/bin
+
+ENV PGDATAOLD /var/lib/postgresql/16/data
+ENV PGDATANEW /var/lib/postgresql/17/data
+
+RUN set -eux; \
+	mkdir -p "$PGDATAOLD" "$PGDATANEW"; \
+	chown -R postgres:postgres /var/lib/postgresql
+
+WORKDIR /var/lib/postgresql
+
+COPY docker-upgrade /usr/local/bin/
+
+ENTRYPOINT ["docker-upgrade"]
+
+# recommended: --link
+CMD ["pg_upgrade"]

--- a/Dockerfile.alpine.template
+++ b/Dockerfile.alpine.template
@@ -1,0 +1,23 @@
+FROM {{ .fromAlpine }}
+
+RUN set -eux; \
+	apk add --no-cache postgresql{{ .old }}
+
+ENV PGBINOLD /usr/libexec/postgresql{{ .old }}
+ENV PGBINNEW /usr/local/bin
+
+ENV PGDATAOLD /var/lib/postgresql/{{ .old }}/data
+ENV PGDATANEW /var/lib/postgresql/{{ .new }}/data
+
+RUN set -eux; \
+	mkdir -p "$PGDATAOLD" "$PGDATANEW"; \
+	chown -R postgres:postgres /var/lib/postgresql
+
+WORKDIR /var/lib/postgresql
+
+COPY docker-upgrade /usr/local/bin/
+
+ENTRYPOINT ["docker-upgrade"]
+
+# recommended: --link
+CMD ["pg_upgrade"]

--- a/apply-templates.sh
+++ b/apply-templates.sh
@@ -39,5 +39,10 @@ for version; do
 		gawk -f "$jqt" Dockerfile.template
 	} > "$version/Dockerfile"
 
+	{
+		generated_warning
+		gawk -f "$jqt" Dockerfile.alpine.template
+	} > "$version/Dockerfile.alpine"
+
 	cp -a docker-upgrade "$version/"
 done

--- a/versions.json
+++ b/versions.json
@@ -1,90 +1,105 @@
 {
   "16-to-17": {
     "from": "postgres:17-bookworm",
+    "fromAlpine": "postgres:17-alpine",
     "new": "17",
     "old": "16",
     "version": "16.4-1.pgdg120+2"
   },
   "15-to-17": {
     "from": "postgres:17-bookworm",
+    "fromAlpine": "postgres:17-alpine",
     "new": "17",
     "old": "15",
     "version": "15.8-1.pgdg120+1"
   },
   "14-to-17": {
     "from": "postgres:17-bookworm",
+    "fromAlpine": "postgres:17-alpine",
     "new": "17",
     "old": "14",
     "version": "14.13-1.pgdg120+1"
   },
   "13-to-17": {
     "from": "postgres:17-bookworm",
+    "fromAlpine": "postgres:17-alpine",
     "new": "17",
     "old": "13",
     "version": "13.16-1.pgdg120+1"
   },
   "12-to-17": {
     "from": "postgres:17-bookworm",
+    "fromAlpine": "postgres:17-alpine",
     "new": "17",
     "old": "12",
     "version": "12.20-1.pgdg120+1"
   },
   "15-to-16": {
     "from": "postgres:16-bookworm",
+    "fromAlpine": "postgres:16-alpine",
     "new": "16",
     "old": "15",
     "version": "15.8-1.pgdg120+1"
   },
   "14-to-16": {
     "from": "postgres:16-bookworm",
+    "fromAlpine": "postgres:16-alpine",
     "new": "16",
     "old": "14",
     "version": "14.13-1.pgdg120+1"
   },
   "13-to-16": {
     "from": "postgres:16-bookworm",
+    "fromAlpine": "postgres:16-alpine",
     "new": "16",
     "old": "13",
     "version": "13.16-1.pgdg120+1"
   },
   "12-to-16": {
     "from": "postgres:16-bookworm",
+    "fromAlpine": "postgres:16-alpine",
     "new": "16",
     "old": "12",
     "version": "12.20-1.pgdg120+1"
   },
   "14-to-15": {
     "from": "postgres:15-bookworm",
+    "fromAlpine": "postgres:15-alpine",
     "new": "15",
     "old": "14",
     "version": "14.13-1.pgdg120+1"
   },
   "13-to-15": {
     "from": "postgres:15-bookworm",
+    "fromAlpine": "postgres:15-alpine",
     "new": "15",
     "old": "13",
     "version": "13.16-1.pgdg120+1"
   },
   "12-to-15": {
     "from": "postgres:15-bookworm",
+    "fromAlpine": "postgres:15-alpine",
     "new": "15",
     "old": "12",
     "version": "12.20-1.pgdg120+1"
   },
   "13-to-14": {
     "from": "postgres:14-bookworm",
+    "fromAlpine": "postgres:14-alpine",
     "new": "14",
     "old": "13",
     "version": "13.16-1.pgdg120+1"
   },
   "12-to-14": {
     "from": "postgres:14-bookworm",
+    "fromAlpine": "postgres:14-alpine",
     "new": "14",
     "old": "12",
     "version": "12.20-1.pgdg120+1"
   },
   "12-to-13": {
     "from": "postgres:13-bookworm",
+    "fromAlpine": "postgres:13-alpine",
     "new": "13",
     "old": "12",
     "version": "12.20-1.pgdg120+1"

--- a/versions.sh
+++ b/versions.sh
@@ -39,8 +39,9 @@ for i in "${!supportedVersions[@]}"; do
 			).suite
 		')"
 		from="postgres:$new-$suite"
+		fromAlpine="postgres:$new-alpine"
 		dir="$old-to-$new"
-		export suite from dir
+		export suite from fromAlpine dir
 		echo "- $old -> $new ($dir; $suite)"
 		postgresCommit="$(bashbrew cat --format '{{ .TagEntry.GitCommit }}' "$doiPostgres:$old-$suite")"
 		versionsURL="https://github.com/docker-library/postgres/raw/$postgresCommit/versions.json"
@@ -51,6 +52,7 @@ for i in "${!supportedVersions[@]}"; do
 		json="$(jq <<<"$json" -c '
 			.[env.dir] = {
 				from: env.from,
+				fromAlpine: env.fromAlpine,
 				new: env.new,
 				old: env.old,
 				version: env.oldVersion,


### PR DESCRIPTION
I successfully migrated a v16 postgres database to v17 with these changes. Alpine offers no `postgres12` and `postgres13` though, so these oldest two versions won't build.

@tianon please tell me what you think about this :blush: I'm happy to find ways to make the upgrade path for alpine rock!