### PR TITLE
Run initdb as PGUSER

### DIFF
--- a/13-to-14/Dockerfile
+++ b/13-to-14/Dockerfile
@@ -15,11 +15,11 @@ RUN set -eux; \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
-ENV PGBINOLD /usr/lib/postgresql/13/bin
-ENV PGBINNEW /usr/lib/postgresql/14/bin
+ENV PGBINOLD=/usr/lib/postgresql/13/bin
+ENV PGBINNEW=/usr/lib/postgresql/14/bin
 
-ENV PGDATAOLD /var/lib/postgresql/13/data
-ENV PGDATANEW /var/lib/postgresql/14/data
+ENV PGDATAOLD=/var/lib/postgresql/13/data
+ENV PGDATANEW=/var/lib/postgresql/14/data
 
 RUN set -eux; \
 	mkdir -p "$PGDATAOLD" "$PGDATANEW"; \

--- a/13-to-14/docker-upgrade
+++ b/13-to-14/docker-upgrade
@@ -1,6 +1,34 @@
 #!/bin/bash
 set -e
 
+if [[ -n "$PGUSER" && -z "$PGUID" ]]; then
+	echo "Error: PGUSER is set to '$PGUSER' but PGUID is not set." >&2
+	exit 1
+fi
+
+if [[ ! "$PGUID" =~ ^[0-9]+$ ]]; then
+	echo "Error: PGUID must be an integer. Current value: '$PGUID'" >&2
+	exit 1
+fi
+
+if [[ -n "$PGUSER" && -z "$PGGID" ]]; then
+	PGGID="$PGUID"
+fi
+
+: "${PGUSER:=postgres}"
+
+if [[ -n "$PGGID" && -z "$(getent group "$PGGID")" ]]; then
+    echo "Creating group '$PGUSER' with GID $PGGID..."
+    addgroup --system --gid "$PGGID" "$PGUSER"
+    echo "Group created."
+fi
+
+if [[ -z "$(getent passwd "$PGUSER")" ]]; then
+	echo "User '$PGUSER' does not exist. Creating..."
+	adduser --system --no-create-home --uid "$PGUID" --gid "$PGGID" --home /var/lib/postgresql --disabled-password "$PGUSER"
+	echo "User '$PGUSER' created."
+fi
+
 if [ "$#" -eq 0 -o "${1:0:1}" = '-' ]; then
 	set -- pg_upgrade "$@"
 fi
@@ -8,9 +36,13 @@ fi
 if [ "$1" = 'pg_upgrade' -a "$(id -u)" = '0' ]; then
 	mkdir -p "$PGDATAOLD" "$PGDATANEW"
 	chmod 700 "$PGDATAOLD" "$PGDATANEW"
-	chown postgres .
-	chown -R postgres "$PGDATAOLD" "$PGDATANEW"
-	exec gosu postgres "$BASH_SOURCE" "$@"
+	chown "$PGUSER" .
+	chown -R "$PGUSER" "$PGDATAOLD" "$PGDATANEW"
+	exec gosu "$PGUSER" "$BASH_SOURCE" "$@"
+fi
+
+if [[ ! "$POSTGRES_INITDB_ARGS" =~ ((--username=|-U[[:space:]])) ]]; then
+    POSTGRES_INITDB_ARGS+=" --username=$PGUSER"
 fi
 
 if [ "$1" = 'pg_upgrade' ]; then

--- a/13-to-14/docker-upgrade
+++ b/13-to-14/docker-upgrade
@@ -1,34 +1,6 @@
 #!/bin/bash
 set -e
 
-if [[ -n "$PGUSER" && -z "$PGUID" ]]; then
-	echo "Error: PGUSER is set to '$PGUSER' but PGUID is not set." >&2
-	exit 1
-fi
-
-if [[ ! "$PGUID" =~ ^[0-9]+$ ]]; then
-	echo "Error: PGUID must be an integer. Current value: '$PGUID'" >&2
-	exit 1
-fi
-
-if [[ -n "$PGUSER" && -z "$PGGID" ]]; then
-	PGGID="$PGUID"
-fi
-
-: "${PGUSER:=postgres}"
-
-if [[ -n "$PGGID" && -z "$(getent group "$PGGID")" ]]; then
-    echo "Creating group '$PGUSER' with GID $PGGID..."
-    addgroup --system --gid "$PGGID" "$PGUSER"
-    echo "Group created."
-fi
-
-if [[ -z "$(getent passwd "$PGUSER")" ]]; then
-	echo "User '$PGUSER' does not exist. Creating..."
-	adduser --system --no-create-home --uid "$PGUID" --gid "$PGGID" --home /var/lib/postgresql --disabled-password "$PGUSER"
-	echo "User '$PGUSER' created."
-fi
-
 if [ "$#" -eq 0 -o "${1:0:1}" = '-' ]; then
 	set -- pg_upgrade "$@"
 fi
@@ -36,12 +8,12 @@ fi
 if [ "$1" = 'pg_upgrade' -a "$(id -u)" = '0' ]; then
 	mkdir -p "$PGDATAOLD" "$PGDATANEW"
 	chmod 700 "$PGDATAOLD" "$PGDATANEW"
-	chown "$PGUSER" .
-	chown -R "$PGUSER" "$PGDATAOLD" "$PGDATANEW"
-	exec gosu "$PGUSER" "$BASH_SOURCE" "$@"
+	chown postgres .
+	chown -R postgres "$PGDATAOLD" "$PGDATANEW"
+	exec gosu postgres "$BASH_SOURCE" "$@"
 fi
 
-if [[ ! "$POSTGRES_INITDB_ARGS" =~ ((--username=|-U[[:space:]])) ]]; then
+if [[ -n "$PGUSER" && ! "$POSTGRES_INITDB_ARGS" =~ ((--username=|-U[[:space:]])) ]]; then
     POSTGRES_INITDB_ARGS+=" --username=$PGUSER"
 fi
 

--- a/13-to-15/Dockerfile
+++ b/13-to-15/Dockerfile
@@ -15,11 +15,11 @@ RUN set -eux; \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
-ENV PGBINOLD /usr/lib/postgresql/13/bin
-ENV PGBINNEW /usr/lib/postgresql/15/bin
+ENV PGBINOLD=/usr/lib/postgresql/13/bin
+ENV PGBINNEW=/usr/lib/postgresql/15/bin
 
-ENV PGDATAOLD /var/lib/postgresql/13/data
-ENV PGDATANEW /var/lib/postgresql/15/data
+ENV PGDATAOLD=/var/lib/postgresql/13/data
+ENV PGDATANEW=/var/lib/postgresql/15/data
 
 RUN set -eux; \
 	mkdir -p "$PGDATAOLD" "$PGDATANEW"; \

--- a/13-to-15/docker-upgrade
+++ b/13-to-15/docker-upgrade
@@ -1,6 +1,34 @@
 #!/bin/bash
 set -e
 
+if [[ -n "$PGUSER" && -z "$PGUID" ]]; then
+	echo "Error: PGUSER is set to '$PGUSER' but PGUID is not set." >&2
+	exit 1
+fi
+
+if [[ ! "$PGUID" =~ ^[0-9]+$ ]]; then
+	echo "Error: PGUID must be an integer. Current value: '$PGUID'" >&2
+	exit 1
+fi
+
+if [[ -n "$PGUSER" && -z "$PGGID" ]]; then
+	PGGID="$PGUID"
+fi
+
+: "${PGUSER:=postgres}"
+
+if [[ -n "$PGGID" && -z "$(getent group "$PGGID")" ]]; then
+    echo "Creating group '$PGUSER' with GID $PGGID..."
+    addgroup --system --gid "$PGGID" "$PGUSER"
+    echo "Group created."
+fi
+
+if [[ -z "$(getent passwd "$PGUSER")" ]]; then
+	echo "User '$PGUSER' does not exist. Creating..."
+	adduser --system --no-create-home --uid "$PGUID" --gid "$PGGID" --home /var/lib/postgresql --disabled-password "$PGUSER"
+	echo "User '$PGUSER' created."
+fi
+
 if [ "$#" -eq 0 -o "${1:0:1}" = '-' ]; then
 	set -- pg_upgrade "$@"
 fi
@@ -8,9 +36,13 @@ fi
 if [ "$1" = 'pg_upgrade' -a "$(id -u)" = '0' ]; then
 	mkdir -p "$PGDATAOLD" "$PGDATANEW"
 	chmod 700 "$PGDATAOLD" "$PGDATANEW"
-	chown postgres .
-	chown -R postgres "$PGDATAOLD" "$PGDATANEW"
-	exec gosu postgres "$BASH_SOURCE" "$@"
+	chown "$PGUSER" .
+	chown -R "$PGUSER" "$PGDATAOLD" "$PGDATANEW"
+	exec gosu "$PGUSER" "$BASH_SOURCE" "$@"
+fi
+
+if [[ ! "$POSTGRES_INITDB_ARGS" =~ ((--username=|-U[[:space:]])) ]]; then
+    POSTGRES_INITDB_ARGS+=" --username=$PGUSER"
 fi
 
 if [ "$1" = 'pg_upgrade' ]; then

--- a/13-to-15/docker-upgrade
+++ b/13-to-15/docker-upgrade
@@ -1,34 +1,6 @@
 #!/bin/bash
 set -e
 
-if [[ -n "$PGUSER" && -z "$PGUID" ]]; then
-	echo "Error: PGUSER is set to '$PGUSER' but PGUID is not set." >&2
-	exit 1
-fi
-
-if [[ ! "$PGUID" =~ ^[0-9]+$ ]]; then
-	echo "Error: PGUID must be an integer. Current value: '$PGUID'" >&2
-	exit 1
-fi
-
-if [[ -n "$PGUSER" && -z "$PGGID" ]]; then
-	PGGID="$PGUID"
-fi
-
-: "${PGUSER:=postgres}"
-
-if [[ -n "$PGGID" && -z "$(getent group "$PGGID")" ]]; then
-    echo "Creating group '$PGUSER' with GID $PGGID..."
-    addgroup --system --gid "$PGGID" "$PGUSER"
-    echo "Group created."
-fi
-
-if [[ -z "$(getent passwd "$PGUSER")" ]]; then
-	echo "User '$PGUSER' does not exist. Creating..."
-	adduser --system --no-create-home --uid "$PGUID" --gid "$PGGID" --home /var/lib/postgresql --disabled-password "$PGUSER"
-	echo "User '$PGUSER' created."
-fi
-
 if [ "$#" -eq 0 -o "${1:0:1}" = '-' ]; then
 	set -- pg_upgrade "$@"
 fi
@@ -36,12 +8,12 @@ fi
 if [ "$1" = 'pg_upgrade' -a "$(id -u)" = '0' ]; then
 	mkdir -p "$PGDATAOLD" "$PGDATANEW"
 	chmod 700 "$PGDATAOLD" "$PGDATANEW"
-	chown "$PGUSER" .
-	chown -R "$PGUSER" "$PGDATAOLD" "$PGDATANEW"
-	exec gosu "$PGUSER" "$BASH_SOURCE" "$@"
+	chown postgres .
+	chown -R postgres "$PGDATAOLD" "$PGDATANEW"
+	exec gosu postgres "$BASH_SOURCE" "$@"
 fi
 
-if [[ ! "$POSTGRES_INITDB_ARGS" =~ ((--username=|-U[[:space:]])) ]]; then
+if [[ -n "$PGUSER" && ! "$POSTGRES_INITDB_ARGS" =~ ((--username=|-U[[:space:]])) ]]; then
     POSTGRES_INITDB_ARGS+=" --username=$PGUSER"
 fi
 

--- a/13-to-16/Dockerfile
+++ b/13-to-16/Dockerfile
@@ -15,11 +15,11 @@ RUN set -eux; \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
-ENV PGBINOLD /usr/lib/postgresql/13/bin
-ENV PGBINNEW /usr/lib/postgresql/16/bin
+ENV PGBINOLD=/usr/lib/postgresql/13/bin
+ENV PGBINNEW=/usr/lib/postgresql/16/bin
 
-ENV PGDATAOLD /var/lib/postgresql/13/data
-ENV PGDATANEW /var/lib/postgresql/16/data
+ENV PGDATAOLD=/var/lib/postgresql/13/data
+ENV PGDATANEW=/var/lib/postgresql/16/data
 
 RUN set -eux; \
 	mkdir -p "$PGDATAOLD" "$PGDATANEW"; \

--- a/13-to-16/docker-upgrade
+++ b/13-to-16/docker-upgrade
@@ -1,6 +1,34 @@
 #!/bin/bash
 set -e
 
+if [[ -n "$PGUSER" && -z "$PGUID" ]]; then
+	echo "Error: PGUSER is set to '$PGUSER' but PGUID is not set." >&2
+	exit 1
+fi
+
+if [[ ! "$PGUID" =~ ^[0-9]+$ ]]; then
+	echo "Error: PGUID must be an integer. Current value: '$PGUID'" >&2
+	exit 1
+fi
+
+if [[ -n "$PGUSER" && -z "$PGGID" ]]; then
+	PGGID="$PGUID"
+fi
+
+: "${PGUSER:=postgres}"
+
+if [[ -n "$PGGID" && -z "$(getent group "$PGGID")" ]]; then
+    echo "Creating group '$PGUSER' with GID $PGGID..."
+    addgroup --system --gid "$PGGID" "$PGUSER"
+    echo "Group created."
+fi
+
+if [[ -z "$(getent passwd "$PGUSER")" ]]; then
+	echo "User '$PGUSER' does not exist. Creating..."
+	adduser --system --no-create-home --uid "$PGUID" --gid "$PGGID" --home /var/lib/postgresql --disabled-password "$PGUSER"
+	echo "User '$PGUSER' created."
+fi
+
 if [ "$#" -eq 0 -o "${1:0:1}" = '-' ]; then
 	set -- pg_upgrade "$@"
 fi
@@ -8,9 +36,13 @@ fi
 if [ "$1" = 'pg_upgrade' -a "$(id -u)" = '0' ]; then
 	mkdir -p "$PGDATAOLD" "$PGDATANEW"
 	chmod 700 "$PGDATAOLD" "$PGDATANEW"
-	chown postgres .
-	chown -R postgres "$PGDATAOLD" "$PGDATANEW"
-	exec gosu postgres "$BASH_SOURCE" "$@"
+	chown "$PGUSER" .
+	chown -R "$PGUSER" "$PGDATAOLD" "$PGDATANEW"
+	exec gosu "$PGUSER" "$BASH_SOURCE" "$@"
+fi
+
+if [[ ! "$POSTGRES_INITDB_ARGS" =~ ((--username=|-U[[:space:]])) ]]; then
+    POSTGRES_INITDB_ARGS+=" --username=$PGUSER"
 fi
 
 if [ "$1" = 'pg_upgrade' ]; then

--- a/13-to-16/docker-upgrade
+++ b/13-to-16/docker-upgrade
@@ -1,34 +1,6 @@
 #!/bin/bash
 set -e
 
-if [[ -n "$PGUSER" && -z "$PGUID" ]]; then
-	echo "Error: PGUSER is set to '$PGUSER' but PGUID is not set." >&2
-	exit 1
-fi
-
-if [[ ! "$PGUID" =~ ^[0-9]+$ ]]; then
-	echo "Error: PGUID must be an integer. Current value: '$PGUID'" >&2
-	exit 1
-fi
-
-if [[ -n "$PGUSER" && -z "$PGGID" ]]; then
-	PGGID="$PGUID"
-fi
-
-: "${PGUSER:=postgres}"
-
-if [[ -n "$PGGID" && -z "$(getent group "$PGGID")" ]]; then
-    echo "Creating group '$PGUSER' with GID $PGGID..."
-    addgroup --system --gid "$PGGID" "$PGUSER"
-    echo "Group created."
-fi
-
-if [[ -z "$(getent passwd "$PGUSER")" ]]; then
-	echo "User '$PGUSER' does not exist. Creating..."
-	adduser --system --no-create-home --uid "$PGUID" --gid "$PGGID" --home /var/lib/postgresql --disabled-password "$PGUSER"
-	echo "User '$PGUSER' created."
-fi
-
 if [ "$#" -eq 0 -o "${1:0:1}" = '-' ]; then
 	set -- pg_upgrade "$@"
 fi
@@ -36,12 +8,12 @@ fi
 if [ "$1" = 'pg_upgrade' -a "$(id -u)" = '0' ]; then
 	mkdir -p "$PGDATAOLD" "$PGDATANEW"
 	chmod 700 "$PGDATAOLD" "$PGDATANEW"
-	chown "$PGUSER" .
-	chown -R "$PGUSER" "$PGDATAOLD" "$PGDATANEW"
-	exec gosu "$PGUSER" "$BASH_SOURCE" "$@"
+	chown postgres .
+	chown -R postgres "$PGDATAOLD" "$PGDATANEW"
+	exec gosu postgres "$BASH_SOURCE" "$@"
 fi
 
-if [[ ! "$POSTGRES_INITDB_ARGS" =~ ((--username=|-U[[:space:]])) ]]; then
+if [[ -n "$PGUSER" && ! "$POSTGRES_INITDB_ARGS" =~ ((--username=|-U[[:space:]])) ]]; then
     POSTGRES_INITDB_ARGS+=" --username=$PGUSER"
 fi
 

--- a/13-to-17/Dockerfile
+++ b/13-to-17/Dockerfile
@@ -15,11 +15,11 @@ RUN set -eux; \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
-ENV PGBINOLD /usr/lib/postgresql/13/bin
-ENV PGBINNEW /usr/lib/postgresql/17/bin
+ENV PGBINOLD=/usr/lib/postgresql/13/bin
+ENV PGBINNEW=/usr/lib/postgresql/17/bin
 
-ENV PGDATAOLD /var/lib/postgresql/13/data
-ENV PGDATANEW /var/lib/postgresql/17/data
+ENV PGDATAOLD=/var/lib/postgresql/13/data
+ENV PGDATANEW=/var/lib/postgresql/17/data
 
 RUN set -eux; \
 	mkdir -p "$PGDATAOLD" "$PGDATANEW"; \

--- a/13-to-17/docker-upgrade
+++ b/13-to-17/docker-upgrade
@@ -1,6 +1,34 @@
 #!/bin/bash
 set -e
 
+if [[ -n "$PGUSER" && -z "$PGUID" ]]; then
+	echo "Error: PGUSER is set to '$PGUSER' but PGUID is not set." >&2
+	exit 1
+fi
+
+if [[ ! "$PGUID" =~ ^[0-9]+$ ]]; then
+	echo "Error: PGUID must be an integer. Current value: '$PGUID'" >&2
+	exit 1
+fi
+
+if [[ -n "$PGUSER" && -z "$PGGID" ]]; then
+	PGGID="$PGUID"
+fi
+
+: "${PGUSER:=postgres}"
+
+if [[ -n "$PGGID" && -z "$(getent group "$PGGID")" ]]; then
+    echo "Creating group '$PGUSER' with GID $PGGID..."
+    addgroup --system --gid "$PGGID" "$PGUSER"
+    echo "Group created."
+fi
+
+if [[ -z "$(getent passwd "$PGUSER")" ]]; then
+	echo "User '$PGUSER' does not exist. Creating..."
+	adduser --system --no-create-home --uid "$PGUID" --gid "$PGGID" --home /var/lib/postgresql --disabled-password "$PGUSER"
+	echo "User '$PGUSER' created."
+fi
+
 if [ "$#" -eq 0 -o "${1:0:1}" = '-' ]; then
 	set -- pg_upgrade "$@"
 fi
@@ -8,9 +36,13 @@ fi
 if [ "$1" = 'pg_upgrade' -a "$(id -u)" = '0' ]; then
 	mkdir -p "$PGDATAOLD" "$PGDATANEW"
 	chmod 700 "$PGDATAOLD" "$PGDATANEW"
-	chown postgres .
-	chown -R postgres "$PGDATAOLD" "$PGDATANEW"
-	exec gosu postgres "$BASH_SOURCE" "$@"
+	chown "$PGUSER" .
+	chown -R "$PGUSER" "$PGDATAOLD" "$PGDATANEW"
+	exec gosu "$PGUSER" "$BASH_SOURCE" "$@"
+fi
+
+if [[ ! "$POSTGRES_INITDB_ARGS" =~ ((--username=|-U[[:space:]])) ]]; then
+    POSTGRES_INITDB_ARGS+=" --username=$PGUSER"
 fi
 
 if [ "$1" = 'pg_upgrade' ]; then

--- a/13-to-17/docker-upgrade
+++ b/13-to-17/docker-upgrade
@@ -1,34 +1,6 @@
 #!/bin/bash
 set -e
 
-if [[ -n "$PGUSER" && -z "$PGUID" ]]; then
-	echo "Error: PGUSER is set to '$PGUSER' but PGUID is not set." >&2
-	exit 1
-fi
-
-if [[ ! "$PGUID" =~ ^[0-9]+$ ]]; then
-	echo "Error: PGUID must be an integer. Current value: '$PGUID'" >&2
-	exit 1
-fi
-
-if [[ -n "$PGUSER" && -z "$PGGID" ]]; then
-	PGGID="$PGUID"
-fi
-
-: "${PGUSER:=postgres}"
-
-if [[ -n "$PGGID" && -z "$(getent group "$PGGID")" ]]; then
-    echo "Creating group '$PGUSER' with GID $PGGID..."
-    addgroup --system --gid "$PGGID" "$PGUSER"
-    echo "Group created."
-fi
-
-if [[ -z "$(getent passwd "$PGUSER")" ]]; then
-	echo "User '$PGUSER' does not exist. Creating..."
-	adduser --system --no-create-home --uid "$PGUID" --gid "$PGGID" --home /var/lib/postgresql --disabled-password "$PGUSER"
-	echo "User '$PGUSER' created."
-fi
-
 if [ "$#" -eq 0 -o "${1:0:1}" = '-' ]; then
 	set -- pg_upgrade "$@"
 fi
@@ -36,12 +8,12 @@ fi
 if [ "$1" = 'pg_upgrade' -a "$(id -u)" = '0' ]; then
 	mkdir -p "$PGDATAOLD" "$PGDATANEW"
 	chmod 700 "$PGDATAOLD" "$PGDATANEW"
-	chown "$PGUSER" .
-	chown -R "$PGUSER" "$PGDATAOLD" "$PGDATANEW"
-	exec gosu "$PGUSER" "$BASH_SOURCE" "$@"
+	chown postgres .
+	chown -R postgres "$PGDATAOLD" "$PGDATANEW"
+	exec gosu postgres "$BASH_SOURCE" "$@"
 fi
 
-if [[ ! "$POSTGRES_INITDB_ARGS" =~ ((--username=|-U[[:space:]])) ]]; then
+if [[ -n "$PGUSER" && ! "$POSTGRES_INITDB_ARGS" =~ ((--username=|-U[[:space:]])) ]]; then
     POSTGRES_INITDB_ARGS+=" --username=$PGUSER"
 fi
 

--- a/14-to-15/Dockerfile
+++ b/14-to-15/Dockerfile
@@ -15,11 +15,11 @@ RUN set -eux; \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
-ENV PGBINOLD /usr/lib/postgresql/14/bin
-ENV PGBINNEW /usr/lib/postgresql/15/bin
+ENV PGBINOLD=/usr/lib/postgresql/14/bin
+ENV PGBINNEW=/usr/lib/postgresql/15/bin
 
-ENV PGDATAOLD /var/lib/postgresql/14/data
-ENV PGDATANEW /var/lib/postgresql/15/data
+ENV PGDATAOLD=/var/lib/postgresql/14/data
+ENV PGDATANEW=/var/lib/postgresql/15/data
 
 RUN set -eux; \
 	mkdir -p "$PGDATAOLD" "$PGDATANEW"; \

--- a/14-to-15/docker-upgrade
+++ b/14-to-15/docker-upgrade
@@ -1,6 +1,34 @@
 #!/bin/bash
 set -e
 
+if [[ -n "$PGUSER" && -z "$PGUID" ]]; then
+	echo "Error: PGUSER is set to '$PGUSER' but PGUID is not set." >&2
+	exit 1
+fi
+
+if [[ ! "$PGUID" =~ ^[0-9]+$ ]]; then
+	echo "Error: PGUID must be an integer. Current value: '$PGUID'" >&2
+	exit 1
+fi
+
+if [[ -n "$PGUSER" && -z "$PGGID" ]]; then
+	PGGID="$PGUID"
+fi
+
+: "${PGUSER:=postgres}"
+
+if [[ -n "$PGGID" && -z "$(getent group "$PGGID")" ]]; then
+    echo "Creating group '$PGUSER' with GID $PGGID..."
+    addgroup --system --gid "$PGGID" "$PGUSER"
+    echo "Group created."
+fi
+
+if [[ -z "$(getent passwd "$PGUSER")" ]]; then
+	echo "User '$PGUSER' does not exist. Creating..."
+	adduser --system --no-create-home --uid "$PGUID" --gid "$PGGID" --home /var/lib/postgresql --disabled-password "$PGUSER"
+	echo "User '$PGUSER' created."
+fi
+
 if [ "$#" -eq 0 -o "${1:0:1}" = '-' ]; then
 	set -- pg_upgrade "$@"
 fi
@@ -8,9 +36,13 @@ fi
 if [ "$1" = 'pg_upgrade' -a "$(id -u)" = '0' ]; then
 	mkdir -p "$PGDATAOLD" "$PGDATANEW"
 	chmod 700 "$PGDATAOLD" "$PGDATANEW"
-	chown postgres .
-	chown -R postgres "$PGDATAOLD" "$PGDATANEW"
-	exec gosu postgres "$BASH_SOURCE" "$@"
+	chown "$PGUSER" .
+	chown -R "$PGUSER" "$PGDATAOLD" "$PGDATANEW"
+	exec gosu "$PGUSER" "$BASH_SOURCE" "$@"
+fi
+
+if [[ ! "$POSTGRES_INITDB_ARGS" =~ ((--username=|-U[[:space:]])) ]]; then
+    POSTGRES_INITDB_ARGS+=" --username=$PGUSER"
 fi
 
 if [ "$1" = 'pg_upgrade' ]; then

--- a/14-to-15/docker-upgrade
+++ b/14-to-15/docker-upgrade
@@ -1,34 +1,6 @@
 #!/bin/bash
 set -e
 
-if [[ -n "$PGUSER" && -z "$PGUID" ]]; then
-	echo "Error: PGUSER is set to '$PGUSER' but PGUID is not set." >&2
-	exit 1
-fi
-
-if [[ ! "$PGUID" =~ ^[0-9]+$ ]]; then
-	echo "Error: PGUID must be an integer. Current value: '$PGUID'" >&2
-	exit 1
-fi
-
-if [[ -n "$PGUSER" && -z "$PGGID" ]]; then
-	PGGID="$PGUID"
-fi
-
-: "${PGUSER:=postgres}"
-
-if [[ -n "$PGGID" && -z "$(getent group "$PGGID")" ]]; then
-    echo "Creating group '$PGUSER' with GID $PGGID..."
-    addgroup --system --gid "$PGGID" "$PGUSER"
-    echo "Group created."
-fi
-
-if [[ -z "$(getent passwd "$PGUSER")" ]]; then
-	echo "User '$PGUSER' does not exist. Creating..."
-	adduser --system --no-create-home --uid "$PGUID" --gid "$PGGID" --home /var/lib/postgresql --disabled-password "$PGUSER"
-	echo "User '$PGUSER' created."
-fi
-
 if [ "$#" -eq 0 -o "${1:0:1}" = '-' ]; then
 	set -- pg_upgrade "$@"
 fi
@@ -36,12 +8,12 @@ fi
 if [ "$1" = 'pg_upgrade' -a "$(id -u)" = '0' ]; then
 	mkdir -p "$PGDATAOLD" "$PGDATANEW"
 	chmod 700 "$PGDATAOLD" "$PGDATANEW"
-	chown "$PGUSER" .
-	chown -R "$PGUSER" "$PGDATAOLD" "$PGDATANEW"
-	exec gosu "$PGUSER" "$BASH_SOURCE" "$@"
+	chown postgres .
+	chown -R postgres "$PGDATAOLD" "$PGDATANEW"
+	exec gosu postgres "$BASH_SOURCE" "$@"
 fi
 
-if [[ ! "$POSTGRES_INITDB_ARGS" =~ ((--username=|-U[[:space:]])) ]]; then
+if [[ -n "$PGUSER" && ! "$POSTGRES_INITDB_ARGS" =~ ((--username=|-U[[:space:]])) ]]; then
     POSTGRES_INITDB_ARGS+=" --username=$PGUSER"
 fi
 

--- a/14-to-16/Dockerfile
+++ b/14-to-16/Dockerfile
@@ -15,11 +15,11 @@ RUN set -eux; \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
-ENV PGBINOLD /usr/lib/postgresql/14/bin
-ENV PGBINNEW /usr/lib/postgresql/16/bin
+ENV PGBINOLD=/usr/lib/postgresql/14/bin
+ENV PGBINNEW=/usr/lib/postgresql/16/bin
 
-ENV PGDATAOLD /var/lib/postgresql/14/data
-ENV PGDATANEW /var/lib/postgresql/16/data
+ENV PGDATAOLD=/var/lib/postgresql/14/data
+ENV PGDATANEW=/var/lib/postgresql/16/data
 
 RUN set -eux; \
 	mkdir -p "$PGDATAOLD" "$PGDATANEW"; \

--- a/14-to-16/docker-upgrade
+++ b/14-to-16/docker-upgrade
@@ -1,6 +1,34 @@
 #!/bin/bash
 set -e
 
+if [[ -n "$PGUSER" && -z "$PGUID" ]]; then
+	echo "Error: PGUSER is set to '$PGUSER' but PGUID is not set." >&2
+	exit 1
+fi
+
+if [[ ! "$PGUID" =~ ^[0-9]+$ ]]; then
+	echo "Error: PGUID must be an integer. Current value: '$PGUID'" >&2
+	exit 1
+fi
+
+if [[ -n "$PGUSER" && -z "$PGGID" ]]; then
+	PGGID="$PGUID"
+fi
+
+: "${PGUSER:=postgres}"
+
+if [[ -n "$PGGID" && -z "$(getent group "$PGGID")" ]]; then
+    echo "Creating group '$PGUSER' with GID $PGGID..."
+    addgroup --system --gid "$PGGID" "$PGUSER"
+    echo "Group created."
+fi
+
+if [[ -z "$(getent passwd "$PGUSER")" ]]; then
+	echo "User '$PGUSER' does not exist. Creating..."
+	adduser --system --no-create-home --uid "$PGUID" --gid "$PGGID" --home /var/lib/postgresql --disabled-password "$PGUSER"
+	echo "User '$PGUSER' created."
+fi
+
 if [ "$#" -eq 0 -o "${1:0:1}" = '-' ]; then
 	set -- pg_upgrade "$@"
 fi
@@ -8,9 +36,13 @@ fi
 if [ "$1" = 'pg_upgrade' -a "$(id -u)" = '0' ]; then
 	mkdir -p "$PGDATAOLD" "$PGDATANEW"
 	chmod 700 "$PGDATAOLD" "$PGDATANEW"
-	chown postgres .
-	chown -R postgres "$PGDATAOLD" "$PGDATANEW"
-	exec gosu postgres "$BASH_SOURCE" "$@"
+	chown "$PGUSER" .
+	chown -R "$PGUSER" "$PGDATAOLD" "$PGDATANEW"
+	exec gosu "$PGUSER" "$BASH_SOURCE" "$@"
+fi
+
+if [[ ! "$POSTGRES_INITDB_ARGS" =~ ((--username=|-U[[:space:]])) ]]; then
+    POSTGRES_INITDB_ARGS+=" --username=$PGUSER"
 fi
 
 if [ "$1" = 'pg_upgrade' ]; then

--- a/14-to-16/docker-upgrade
+++ b/14-to-16/docker-upgrade
@@ -1,34 +1,6 @@
 #!/bin/bash
 set -e
 
-if [[ -n "$PGUSER" && -z "$PGUID" ]]; then
-	echo "Error: PGUSER is set to '$PGUSER' but PGUID is not set." >&2
-	exit 1
-fi
-
-if [[ ! "$PGUID" =~ ^[0-9]+$ ]]; then
-	echo "Error: PGUID must be an integer. Current value: '$PGUID'" >&2
-	exit 1
-fi
-
-if [[ -n "$PGUSER" && -z "$PGGID" ]]; then
-	PGGID="$PGUID"
-fi
-
-: "${PGUSER:=postgres}"
-
-if [[ -n "$PGGID" && -z "$(getent group "$PGGID")" ]]; then
-    echo "Creating group '$PGUSER' with GID $PGGID..."
-    addgroup --system --gid "$PGGID" "$PGUSER"
-    echo "Group created."
-fi
-
-if [[ -z "$(getent passwd "$PGUSER")" ]]; then
-	echo "User '$PGUSER' does not exist. Creating..."
-	adduser --system --no-create-home --uid "$PGUID" --gid "$PGGID" --home /var/lib/postgresql --disabled-password "$PGUSER"
-	echo "User '$PGUSER' created."
-fi
-
 if [ "$#" -eq 0 -o "${1:0:1}" = '-' ]; then
 	set -- pg_upgrade "$@"
 fi
@@ -36,12 +8,12 @@ fi
 if [ "$1" = 'pg_upgrade' -a "$(id -u)" = '0' ]; then
 	mkdir -p "$PGDATAOLD" "$PGDATANEW"
 	chmod 700 "$PGDATAOLD" "$PGDATANEW"
-	chown "$PGUSER" .
-	chown -R "$PGUSER" "$PGDATAOLD" "$PGDATANEW"
-	exec gosu "$PGUSER" "$BASH_SOURCE" "$@"
+	chown postgres .
+	chown -R postgres "$PGDATAOLD" "$PGDATANEW"
+	exec gosu postgres "$BASH_SOURCE" "$@"
 fi
 
-if [[ ! "$POSTGRES_INITDB_ARGS" =~ ((--username=|-U[[:space:]])) ]]; then
+if [[ -n "$PGUSER" && ! "$POSTGRES_INITDB_ARGS" =~ ((--username=|-U[[:space:]])) ]]; then
     POSTGRES_INITDB_ARGS+=" --username=$PGUSER"
 fi
 

--- a/14-to-17/Dockerfile
+++ b/14-to-17/Dockerfile
@@ -15,11 +15,11 @@ RUN set -eux; \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
-ENV PGBINOLD /usr/lib/postgresql/14/bin
-ENV PGBINNEW /usr/lib/postgresql/17/bin
+ENV PGBINOLD=/usr/lib/postgresql/14/bin
+ENV PGBINNEW=/usr/lib/postgresql/17/bin
 
-ENV PGDATAOLD /var/lib/postgresql/14/data
-ENV PGDATANEW /var/lib/postgresql/17/data
+ENV PGDATAOLD=/var/lib/postgresql/14/data
+ENV PGDATANEW=/var/lib/postgresql/17/data
 
 RUN set -eux; \
 	mkdir -p "$PGDATAOLD" "$PGDATANEW"; \

--- a/14-to-17/docker-upgrade
+++ b/14-to-17/docker-upgrade
@@ -1,6 +1,34 @@
 #!/bin/bash
 set -e
 
+if [[ -n "$PGUSER" && -z "$PGUID" ]]; then
+	echo "Error: PGUSER is set to '$PGUSER' but PGUID is not set." >&2
+	exit 1
+fi
+
+if [[ ! "$PGUID" =~ ^[0-9]+$ ]]; then
+	echo "Error: PGUID must be an integer. Current value: '$PGUID'" >&2
+	exit 1
+fi
+
+if [[ -n "$PGUSER" && -z "$PGGID" ]]; then
+	PGGID="$PGUID"
+fi
+
+: "${PGUSER:=postgres}"
+
+if [[ -n "$PGGID" && -z "$(getent group "$PGGID")" ]]; then
+    echo "Creating group '$PGUSER' with GID $PGGID..."
+    addgroup --system --gid "$PGGID" "$PGUSER"
+    echo "Group created."
+fi
+
+if [[ -z "$(getent passwd "$PGUSER")" ]]; then
+	echo "User '$PGUSER' does not exist. Creating..."
+	adduser --system --no-create-home --uid "$PGUID" --gid "$PGGID" --home /var/lib/postgresql --disabled-password "$PGUSER"
+	echo "User '$PGUSER' created."
+fi
+
 if [ "$#" -eq 0 -o "${1:0:1}" = '-' ]; then
 	set -- pg_upgrade "$@"
 fi
@@ -8,9 +36,13 @@ fi
 if [ "$1" = 'pg_upgrade' -a "$(id -u)" = '0' ]; then
 	mkdir -p "$PGDATAOLD" "$PGDATANEW"
 	chmod 700 "$PGDATAOLD" "$PGDATANEW"
-	chown postgres .
-	chown -R postgres "$PGDATAOLD" "$PGDATANEW"
-	exec gosu postgres "$BASH_SOURCE" "$@"
+	chown "$PGUSER" .
+	chown -R "$PGUSER" "$PGDATAOLD" "$PGDATANEW"
+	exec gosu "$PGUSER" "$BASH_SOURCE" "$@"
+fi
+
+if [[ ! "$POSTGRES_INITDB_ARGS" =~ ((--username=|-U[[:space:]])) ]]; then
+    POSTGRES_INITDB_ARGS+=" --username=$PGUSER"
 fi
 
 if [ "$1" = 'pg_upgrade' ]; then

--- a/14-to-17/docker-upgrade
+++ b/14-to-17/docker-upgrade
@@ -1,34 +1,6 @@
 #!/bin/bash
 set -e
 
-if [[ -n "$PGUSER" && -z "$PGUID" ]]; then
-	echo "Error: PGUSER is set to '$PGUSER' but PGUID is not set." >&2
-	exit 1
-fi
-
-if [[ ! "$PGUID" =~ ^[0-9]+$ ]]; then
-	echo "Error: PGUID must be an integer. Current value: '$PGUID'" >&2
-	exit 1
-fi
-
-if [[ -n "$PGUSER" && -z "$PGGID" ]]; then
-	PGGID="$PGUID"
-fi
-
-: "${PGUSER:=postgres}"
-
-if [[ -n "$PGGID" && -z "$(getent group "$PGGID")" ]]; then
-    echo "Creating group '$PGUSER' with GID $PGGID..."
-    addgroup --system --gid "$PGGID" "$PGUSER"
-    echo "Group created."
-fi
-
-if [[ -z "$(getent passwd "$PGUSER")" ]]; then
-	echo "User '$PGUSER' does not exist. Creating..."
-	adduser --system --no-create-home --uid "$PGUID" --gid "$PGGID" --home /var/lib/postgresql --disabled-password "$PGUSER"
-	echo "User '$PGUSER' created."
-fi
-
 if [ "$#" -eq 0 -o "${1:0:1}" = '-' ]; then
 	set -- pg_upgrade "$@"
 fi
@@ -36,12 +8,12 @@ fi
 if [ "$1" = 'pg_upgrade' -a "$(id -u)" = '0' ]; then
 	mkdir -p "$PGDATAOLD" "$PGDATANEW"
 	chmod 700 "$PGDATAOLD" "$PGDATANEW"
-	chown "$PGUSER" .
-	chown -R "$PGUSER" "$PGDATAOLD" "$PGDATANEW"
-	exec gosu "$PGUSER" "$BASH_SOURCE" "$@"
+	chown postgres .
+	chown -R postgres "$PGDATAOLD" "$PGDATANEW"
+	exec gosu postgres "$BASH_SOURCE" "$@"
 fi
 
-if [[ ! "$POSTGRES_INITDB_ARGS" =~ ((--username=|-U[[:space:]])) ]]; then
+if [[ -n "$PGUSER" && ! "$POSTGRES_INITDB_ARGS" =~ ((--username=|-U[[:space:]])) ]]; then
     POSTGRES_INITDB_ARGS+=" --username=$PGUSER"
 fi
 

--- a/15-to-16/Dockerfile
+++ b/15-to-16/Dockerfile
@@ -15,11 +15,11 @@ RUN set -eux; \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
-ENV PGBINOLD /usr/lib/postgresql/15/bin
-ENV PGBINNEW /usr/lib/postgresql/16/bin
+ENV PGBINOLD=/usr/lib/postgresql/15/bin
+ENV PGBINNEW=/usr/lib/postgresql/16/bin
 
-ENV PGDATAOLD /var/lib/postgresql/15/data
-ENV PGDATANEW /var/lib/postgresql/16/data
+ENV PGDATAOLD=/var/lib/postgresql/15/data
+ENV PGDATANEW=/var/lib/postgresql/16/data
 
 RUN set -eux; \
 	mkdir -p "$PGDATAOLD" "$PGDATANEW"; \

--- a/15-to-16/docker-upgrade
+++ b/15-to-16/docker-upgrade
@@ -1,6 +1,34 @@
 #!/bin/bash
 set -e
 
+if [[ -n "$PGUSER" && -z "$PGUID" ]]; then
+	echo "Error: PGUSER is set to '$PGUSER' but PGUID is not set." >&2
+	exit 1
+fi
+
+if [[ ! "$PGUID" =~ ^[0-9]+$ ]]; then
+	echo "Error: PGUID must be an integer. Current value: '$PGUID'" >&2
+	exit 1
+fi
+
+if [[ -n "$PGUSER" && -z "$PGGID" ]]; then
+	PGGID="$PGUID"
+fi
+
+: "${PGUSER:=postgres}"
+
+if [[ -n "$PGGID" && -z "$(getent group "$PGGID")" ]]; then
+    echo "Creating group '$PGUSER' with GID $PGGID..."
+    addgroup --system --gid "$PGGID" "$PGUSER"
+    echo "Group created."
+fi
+
+if [[ -z "$(getent passwd "$PGUSER")" ]]; then
+	echo "User '$PGUSER' does not exist. Creating..."
+	adduser --system --no-create-home --uid "$PGUID" --gid "$PGGID" --home /var/lib/postgresql --disabled-password "$PGUSER"
+	echo "User '$PGUSER' created."
+fi
+
 if [ "$#" -eq 0 -o "${1:0:1}" = '-' ]; then
 	set -- pg_upgrade "$@"
 fi
@@ -8,9 +36,13 @@ fi
 if [ "$1" = 'pg_upgrade' -a "$(id -u)" = '0' ]; then
 	mkdir -p "$PGDATAOLD" "$PGDATANEW"
 	chmod 700 "$PGDATAOLD" "$PGDATANEW"
-	chown postgres .
-	chown -R postgres "$PGDATAOLD" "$PGDATANEW"
-	exec gosu postgres "$BASH_SOURCE" "$@"
+	chown "$PGUSER" .
+	chown -R "$PGUSER" "$PGDATAOLD" "$PGDATANEW"
+	exec gosu "$PGUSER" "$BASH_SOURCE" "$@"
+fi
+
+if [[ ! "$POSTGRES_INITDB_ARGS" =~ ((--username=|-U[[:space:]])) ]]; then
+    POSTGRES_INITDB_ARGS+=" --username=$PGUSER"
 fi
 
 if [ "$1" = 'pg_upgrade' ]; then

--- a/15-to-16/docker-upgrade
+++ b/15-to-16/docker-upgrade
@@ -1,34 +1,6 @@
 #!/bin/bash
 set -e
 
-if [[ -n "$PGUSER" && -z "$PGUID" ]]; then
-	echo "Error: PGUSER is set to '$PGUSER' but PGUID is not set." >&2
-	exit 1
-fi
-
-if [[ ! "$PGUID" =~ ^[0-9]+$ ]]; then
-	echo "Error: PGUID must be an integer. Current value: '$PGUID'" >&2
-	exit 1
-fi
-
-if [[ -n "$PGUSER" && -z "$PGGID" ]]; then
-	PGGID="$PGUID"
-fi
-
-: "${PGUSER:=postgres}"
-
-if [[ -n "$PGGID" && -z "$(getent group "$PGGID")" ]]; then
-    echo "Creating group '$PGUSER' with GID $PGGID..."
-    addgroup --system --gid "$PGGID" "$PGUSER"
-    echo "Group created."
-fi
-
-if [[ -z "$(getent passwd "$PGUSER")" ]]; then
-	echo "User '$PGUSER' does not exist. Creating..."
-	adduser --system --no-create-home --uid "$PGUID" --gid "$PGGID" --home /var/lib/postgresql --disabled-password "$PGUSER"
-	echo "User '$PGUSER' created."
-fi
-
 if [ "$#" -eq 0 -o "${1:0:1}" = '-' ]; then
 	set -- pg_upgrade "$@"
 fi
@@ -36,12 +8,12 @@ fi
 if [ "$1" = 'pg_upgrade' -a "$(id -u)" = '0' ]; then
 	mkdir -p "$PGDATAOLD" "$PGDATANEW"
 	chmod 700 "$PGDATAOLD" "$PGDATANEW"
-	chown "$PGUSER" .
-	chown -R "$PGUSER" "$PGDATAOLD" "$PGDATANEW"
-	exec gosu "$PGUSER" "$BASH_SOURCE" "$@"
+	chown postgres .
+	chown -R postgres "$PGDATAOLD" "$PGDATANEW"
+	exec gosu postgres "$BASH_SOURCE" "$@"
 fi
 
-if [[ ! "$POSTGRES_INITDB_ARGS" =~ ((--username=|-U[[:space:]])) ]]; then
+if [[ -n "$PGUSER" && ! "$POSTGRES_INITDB_ARGS" =~ ((--username=|-U[[:space:]])) ]]; then
     POSTGRES_INITDB_ARGS+=" --username=$PGUSER"
 fi
 

--- a/15-to-17/Dockerfile
+++ b/15-to-17/Dockerfile
@@ -15,11 +15,11 @@ RUN set -eux; \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
-ENV PGBINOLD /usr/lib/postgresql/15/bin
-ENV PGBINNEW /usr/lib/postgresql/17/bin
+ENV PGBINOLD=/usr/lib/postgresql/15/bin
+ENV PGBINNEW=/usr/lib/postgresql/17/bin
 
-ENV PGDATAOLD /var/lib/postgresql/15/data
-ENV PGDATANEW /var/lib/postgresql/17/data
+ENV PGDATAOLD=/var/lib/postgresql/15/data
+ENV PGDATANEW=/var/lib/postgresql/17/data
 
 RUN set -eux; \
 	mkdir -p "$PGDATAOLD" "$PGDATANEW"; \

--- a/15-to-17/docker-upgrade
+++ b/15-to-17/docker-upgrade
@@ -1,6 +1,34 @@
 #!/bin/bash
 set -e
 
+if [[ -n "$PGUSER" && -z "$PGUID" ]]; then
+	echo "Error: PGUSER is set to '$PGUSER' but PGUID is not set." >&2
+	exit 1
+fi
+
+if [[ ! "$PGUID" =~ ^[0-9]+$ ]]; then
+	echo "Error: PGUID must be an integer. Current value: '$PGUID'" >&2
+	exit 1
+fi
+
+if [[ -n "$PGUSER" && -z "$PGGID" ]]; then
+	PGGID="$PGUID"
+fi
+
+: "${PGUSER:=postgres}"
+
+if [[ -n "$PGGID" && -z "$(getent group "$PGGID")" ]]; then
+    echo "Creating group '$PGUSER' with GID $PGGID..."
+    addgroup --system --gid "$PGGID" "$PGUSER"
+    echo "Group created."
+fi
+
+if [[ -z "$(getent passwd "$PGUSER")" ]]; then
+	echo "User '$PGUSER' does not exist. Creating..."
+	adduser --system --no-create-home --uid "$PGUID" --gid "$PGGID" --home /var/lib/postgresql --disabled-password "$PGUSER"
+	echo "User '$PGUSER' created."
+fi
+
 if [ "$#" -eq 0 -o "${1:0:1}" = '-' ]; then
 	set -- pg_upgrade "$@"
 fi
@@ -8,9 +36,13 @@ fi
 if [ "$1" = 'pg_upgrade' -a "$(id -u)" = '0' ]; then
 	mkdir -p "$PGDATAOLD" "$PGDATANEW"
 	chmod 700 "$PGDATAOLD" "$PGDATANEW"
-	chown postgres .
-	chown -R postgres "$PGDATAOLD" "$PGDATANEW"
-	exec gosu postgres "$BASH_SOURCE" "$@"
+	chown "$PGUSER" .
+	chown -R "$PGUSER" "$PGDATAOLD" "$PGDATANEW"
+	exec gosu "$PGUSER" "$BASH_SOURCE" "$@"
+fi
+
+if [[ ! "$POSTGRES_INITDB_ARGS" =~ ((--username=|-U[[:space:]])) ]]; then
+    POSTGRES_INITDB_ARGS+=" --username=$PGUSER"
 fi
 
 if [ "$1" = 'pg_upgrade' ]; then

--- a/15-to-17/docker-upgrade
+++ b/15-to-17/docker-upgrade
@@ -1,34 +1,6 @@
 #!/bin/bash
 set -e
 
-if [[ -n "$PGUSER" && -z "$PGUID" ]]; then
-	echo "Error: PGUSER is set to '$PGUSER' but PGUID is not set." >&2
-	exit 1
-fi
-
-if [[ ! "$PGUID" =~ ^[0-9]+$ ]]; then
-	echo "Error: PGUID must be an integer. Current value: '$PGUID'" >&2
-	exit 1
-fi
-
-if [[ -n "$PGUSER" && -z "$PGGID" ]]; then
-	PGGID="$PGUID"
-fi
-
-: "${PGUSER:=postgres}"
-
-if [[ -n "$PGGID" && -z "$(getent group "$PGGID")" ]]; then
-    echo "Creating group '$PGUSER' with GID $PGGID..."
-    addgroup --system --gid "$PGGID" "$PGUSER"
-    echo "Group created."
-fi
-
-if [[ -z "$(getent passwd "$PGUSER")" ]]; then
-	echo "User '$PGUSER' does not exist. Creating..."
-	adduser --system --no-create-home --uid "$PGUID" --gid "$PGGID" --home /var/lib/postgresql --disabled-password "$PGUSER"
-	echo "User '$PGUSER' created."
-fi
-
 if [ "$#" -eq 0 -o "${1:0:1}" = '-' ]; then
 	set -- pg_upgrade "$@"
 fi
@@ -36,12 +8,12 @@ fi
 if [ "$1" = 'pg_upgrade' -a "$(id -u)" = '0' ]; then
 	mkdir -p "$PGDATAOLD" "$PGDATANEW"
 	chmod 700 "$PGDATAOLD" "$PGDATANEW"
-	chown "$PGUSER" .
-	chown -R "$PGUSER" "$PGDATAOLD" "$PGDATANEW"
-	exec gosu "$PGUSER" "$BASH_SOURCE" "$@"
+	chown postgres .
+	chown -R postgres "$PGDATAOLD" "$PGDATANEW"
+	exec gosu postgres "$BASH_SOURCE" "$@"
 fi
 
-if [[ ! "$POSTGRES_INITDB_ARGS" =~ ((--username=|-U[[:space:]])) ]]; then
+if [[ -n "$PGUSER" && ! "$POSTGRES_INITDB_ARGS" =~ ((--username=|-U[[:space:]])) ]]; then
     POSTGRES_INITDB_ARGS+=" --username=$PGUSER"
 fi
 

--- a/16-to-17/Dockerfile
+++ b/16-to-17/Dockerfile
@@ -15,11 +15,11 @@ RUN set -eux; \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
-ENV PGBINOLD /usr/lib/postgresql/16/bin
-ENV PGBINNEW /usr/lib/postgresql/17/bin
+ENV PGBINOLD=/usr/lib/postgresql/16/bin
+ENV PGBINNEW=/usr/lib/postgresql/17/bin
 
-ENV PGDATAOLD /var/lib/postgresql/16/data
-ENV PGDATANEW /var/lib/postgresql/17/data
+ENV PGDATAOLD=/var/lib/postgresql/16/data
+ENV PGDATANEW=/var/lib/postgresql/17/data
 
 RUN set -eux; \
 	mkdir -p "$PGDATAOLD" "$PGDATANEW"; \

--- a/16-to-17/docker-upgrade
+++ b/16-to-17/docker-upgrade
@@ -1,6 +1,34 @@
 #!/bin/bash
 set -e
 
+if [[ -n "$PGUSER" && -z "$PGUID" ]]; then
+	echo "Error: PGUSER is set to '$PGUSER' but PGUID is not set." >&2
+	exit 1
+fi
+
+if [[ ! "$PGUID" =~ ^[0-9]+$ ]]; then
+	echo "Error: PGUID must be an integer. Current value: '$PGUID'" >&2
+	exit 1
+fi
+
+if [[ -n "$PGUSER" && -z "$PGGID" ]]; then
+	PGGID="$PGUID"
+fi
+
+: "${PGUSER:=postgres}"
+
+if [[ -n "$PGGID" && -z "$(getent group "$PGGID")" ]]; then
+    echo "Creating group '$PGUSER' with GID $PGGID..."
+    addgroup --system --gid "$PGGID" "$PGUSER"
+    echo "Group created."
+fi
+
+if [[ -z "$(getent passwd "$PGUSER")" ]]; then
+	echo "User '$PGUSER' does not exist. Creating..."
+	adduser --system --no-create-home --uid "$PGUID" --gid "$PGGID" --home /var/lib/postgresql --disabled-password "$PGUSER"
+	echo "User '$PGUSER' created."
+fi
+
 if [ "$#" -eq 0 -o "${1:0:1}" = '-' ]; then
 	set -- pg_upgrade "$@"
 fi
@@ -8,9 +36,13 @@ fi
 if [ "$1" = 'pg_upgrade' -a "$(id -u)" = '0' ]; then
 	mkdir -p "$PGDATAOLD" "$PGDATANEW"
 	chmod 700 "$PGDATAOLD" "$PGDATANEW"
-	chown postgres .
-	chown -R postgres "$PGDATAOLD" "$PGDATANEW"
-	exec gosu postgres "$BASH_SOURCE" "$@"
+	chown "$PGUSER" .
+	chown -R "$PGUSER" "$PGDATAOLD" "$PGDATANEW"
+	exec gosu "$PGUSER" "$BASH_SOURCE" "$@"
+fi
+
+if [[ ! "$POSTGRES_INITDB_ARGS" =~ ((--username=|-U[[:space:]])) ]]; then
+    POSTGRES_INITDB_ARGS+=" --username=$PGUSER"
 fi
 
 if [ "$1" = 'pg_upgrade' ]; then

--- a/16-to-17/docker-upgrade
+++ b/16-to-17/docker-upgrade
@@ -1,34 +1,6 @@
 #!/bin/bash
 set -e
 
-if [[ -n "$PGUSER" && -z "$PGUID" ]]; then
-	echo "Error: PGUSER is set to '$PGUSER' but PGUID is not set." >&2
-	exit 1
-fi
-
-if [[ ! "$PGUID" =~ ^[0-9]+$ ]]; then
-	echo "Error: PGUID must be an integer. Current value: '$PGUID'" >&2
-	exit 1
-fi
-
-if [[ -n "$PGUSER" && -z "$PGGID" ]]; then
-	PGGID="$PGUID"
-fi
-
-: "${PGUSER:=postgres}"
-
-if [[ -n "$PGGID" && -z "$(getent group "$PGGID")" ]]; then
-    echo "Creating group '$PGUSER' with GID $PGGID..."
-    addgroup --system --gid "$PGGID" "$PGUSER"
-    echo "Group created."
-fi
-
-if [[ -z "$(getent passwd "$PGUSER")" ]]; then
-	echo "User '$PGUSER' does not exist. Creating..."
-	adduser --system --no-create-home --uid "$PGUID" --gid "$PGGID" --home /var/lib/postgresql --disabled-password "$PGUSER"
-	echo "User '$PGUSER' created."
-fi
-
 if [ "$#" -eq 0 -o "${1:0:1}" = '-' ]; then
 	set -- pg_upgrade "$@"
 fi
@@ -36,12 +8,12 @@ fi
 if [ "$1" = 'pg_upgrade' -a "$(id -u)" = '0' ]; then
 	mkdir -p "$PGDATAOLD" "$PGDATANEW"
 	chmod 700 "$PGDATAOLD" "$PGDATANEW"
-	chown "$PGUSER" .
-	chown -R "$PGUSER" "$PGDATAOLD" "$PGDATANEW"
-	exec gosu "$PGUSER" "$BASH_SOURCE" "$@"
+	chown postgres .
+	chown -R postgres "$PGDATAOLD" "$PGDATANEW"
+	exec gosu postgres "$BASH_SOURCE" "$@"
 fi
 
-if [[ ! "$POSTGRES_INITDB_ARGS" =~ ((--username=|-U[[:space:]])) ]]; then
+if [[ -n "$PGUSER" && ! "$POSTGRES_INITDB_ARGS" =~ ((--username=|-U[[:space:]])) ]]; then
     POSTGRES_INITDB_ARGS+=" --username=$PGUSER"
 fi
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -9,11 +9,11 @@ RUN set -eux; \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
-ENV PGBINOLD /usr/lib/postgresql/{{ .old }}/bin
-ENV PGBINNEW /usr/lib/postgresql/{{ .new }}/bin
+ENV PGBINOLD=/usr/lib/postgresql/{{ .old }}/bin
+ENV PGBINNEW=/usr/lib/postgresql/{{ .new }}/bin
 
-ENV PGDATAOLD /var/lib/postgresql/{{ .old }}/data
-ENV PGDATANEW /var/lib/postgresql/{{ .new }}/data
+ENV PGDATAOLD=/var/lib/postgresql/{{ .old }}/data
+ENV PGDATANEW=/var/lib/postgresql/{{ .new }}/data
 
 RUN set -eux; \
 	mkdir -p "$PGDATAOLD" "$PGDATANEW"; \

--- a/docker-upgrade
+++ b/docker-upgrade
@@ -1,6 +1,34 @@
 #!/bin/bash
 set -e
 
+if [[ -n "$PGUSER" && -z "$PGUID" ]]; then
+	echo "Error: PGUSER is set to '$PGUSER' but PGUID is not set." >&2
+	exit 1
+fi
+
+if [[ ! "$PGUID" =~ ^[0-9]+$ ]]; then
+	echo "Error: PGUID must be an integer. Current value: '$PGUID'" >&2
+	exit 1
+fi
+
+if [[ -n "$PGUSER" && -z "$PGGID" ]]; then
+	PGGID="$PGUID"
+fi
+
+: "${PGUSER:=postgres}"
+
+if [[ -n "$PGGID" && -z "$(getent group "$PGGID")" ]]; then
+    echo "Creating group '$PGUSER' with GID $PGGID..."
+    addgroup --system --gid "$PGGID" "$PGUSER"
+    echo "Group created."
+fi
+
+if [[ -z "$(getent passwd "$PGUSER")" ]]; then
+	echo "User '$PGUSER' does not exist. Creating..."
+	adduser --system --no-create-home --uid "$PGUID" --gid "$PGGID" --home /var/lib/postgresql --disabled-password "$PGUSER"
+	echo "User '$PGUSER' created."
+fi
+
 if [ "$#" -eq 0 -o "${1:0:1}" = '-' ]; then
 	set -- pg_upgrade "$@"
 fi
@@ -8,9 +36,13 @@ fi
 if [ "$1" = 'pg_upgrade' -a "$(id -u)" = '0' ]; then
 	mkdir -p "$PGDATAOLD" "$PGDATANEW"
 	chmod 700 "$PGDATAOLD" "$PGDATANEW"
-	chown postgres .
-	chown -R postgres "$PGDATAOLD" "$PGDATANEW"
-	exec gosu postgres "$BASH_SOURCE" "$@"
+	chown "$PGUSER" .
+	chown -R "$PGUSER" "$PGDATAOLD" "$PGDATANEW"
+	exec gosu "$PGUSER" "$BASH_SOURCE" "$@"
+fi
+
+if [[ ! "$POSTGRES_INITDB_ARGS" =~ ((--username=|-U[[:space:]])) ]]; then
+    POSTGRES_INITDB_ARGS+=" --username=$PGUSER"
 fi
 
 if [ "$1" = 'pg_upgrade' ]; then

--- a/docker-upgrade
+++ b/docker-upgrade
@@ -1,34 +1,6 @@
 #!/bin/bash
 set -e
 
-if [[ -n "$PGUSER" && -z "$PGUID" ]]; then
-	echo "Error: PGUSER is set to '$PGUSER' but PGUID is not set." >&2
-	exit 1
-fi
-
-if [[ ! "$PGUID" =~ ^[0-9]+$ ]]; then
-	echo "Error: PGUID must be an integer. Current value: '$PGUID'" >&2
-	exit 1
-fi
-
-if [[ -n "$PGUSER" && -z "$PGGID" ]]; then
-	PGGID="$PGUID"
-fi
-
-: "${PGUSER:=postgres}"
-
-if [[ -n "$PGGID" && -z "$(getent group "$PGGID")" ]]; then
-    echo "Creating group '$PGUSER' with GID $PGGID..."
-    addgroup --system --gid "$PGGID" "$PGUSER"
-    echo "Group created."
-fi
-
-if [[ -z "$(getent passwd "$PGUSER")" ]]; then
-	echo "User '$PGUSER' does not exist. Creating..."
-	adduser --system --no-create-home --uid "$PGUID" --gid "$PGGID" --home /var/lib/postgresql --disabled-password "$PGUSER"
-	echo "User '$PGUSER' created."
-fi
-
 if [ "$#" -eq 0 -o "${1:0:1}" = '-' ]; then
 	set -- pg_upgrade "$@"
 fi
@@ -36,12 +8,12 @@ fi
 if [ "$1" = 'pg_upgrade' -a "$(id -u)" = '0' ]; then
 	mkdir -p "$PGDATAOLD" "$PGDATANEW"
 	chmod 700 "$PGDATAOLD" "$PGDATANEW"
-	chown "$PGUSER" .
-	chown -R "$PGUSER" "$PGDATAOLD" "$PGDATANEW"
-	exec gosu "$PGUSER" "$BASH_SOURCE" "$@"
+	chown postgres .
+	chown -R postgres "$PGDATAOLD" "$PGDATANEW"
+	exec gosu postgres "$BASH_SOURCE" "$@"
 fi
 
-if [[ ! "$POSTGRES_INITDB_ARGS" =~ ((--username=|-U[[:space:]])) ]]; then
+if [[ -n "$PGUSER" && ! "$POSTGRES_INITDB_ARGS" =~ ((--username=|-U[[:space:]])) ]]; then
     POSTGRES_INITDB_ARGS+=" --username=$PGUSER"
 fi
 


### PR DESCRIPTION
When running pg_upgrade with the PGUSER environment variable set the destination database bootstrap user must also be set to the same user.

If the environment variable PGUSER is set the username option gets appended to the variable POSTGRES_INITDB_ARGS