### PR TITLE
Add arm64 support to all the latest "target" version images (currently *-to-17)

### DIFF
--- a/generate-stackbrew-library.jq
+++ b/generate-stackbrew-library.jq
@@ -1,0 +1,28 @@
+"Maintainers: Tianon Gravi <tianon@tianon.xyz> (@tianon)",
+"GitRepo: https://github.com/tianon/docker-postgres-upgrade.git",
+"GitCommit: \($commit)",
+
+(
+	first(.[].new) as $newest
+
+	| to_entries[]
+
+	| if $ARGS.positional | length > 0 then
+		select(IN(.key; $ARGS.positional[]))
+	else . end
+
+	| (
+		"",
+		"Tags: \(.key)",
+		"Directory: \(.key)",
+		"Architectures: \(
+			if .value.new == $newest then
+				# only the newest (target) version gets more than one architecture
+				# https://github.com/tianon/docker-postgres-upgrade/issues/99#issuecomment-3235566575
+				"amd64, arm64v8"
+				# TODO update "versions.sh" to also scrape/keep "Architectures" data from the upstream bashbrew files so this doesn't ever accidentally include things that don't exist or shouldn't be supported
+			else "amd64" end
+		)",
+		empty
+	)
+)

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -1,28 +1,13 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-self="$(basename "$BASH_SOURCE")"
 cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
-
-if [ "$#" -eq 0 ]; then
-	versions="$(jq -r 'keys_unsorted | map(@sh) | join(" ")' versions.json)"
-	eval "set -- $versions"
-fi
 
 commit="$(git log -1 --format='format:%H' HEAD)"
 
-cat <<-EOH
-	Maintainers: Tianon Gravi <tianon@tianon.xyz> (@tianon)
-	GitRepo: https://github.com/tianon/docker-postgres-upgrade.git
-	GitCommit: $commit
-EOH
-
-for version; do
-	export version
-
-	cat <<-EOE
-
-		Tags: $version
-		Directory: $version
-	EOE
-done
+exec jq \
+	--raw-output \
+	--arg commit "$commit" \
+	--from-file generate-stackbrew-library.jq \
+	versions.json \
+	--args -- "$@"


### PR DESCRIPTION
- Closes #99
- #43
- #82
- #85

Also, convert `generate-stackbrew-library.sh` *fully* to `jq`:

```diff
$ diff -u <(bashbrew cat https://github.com/tianon/bashbrew-tianon/raw/HEAD/library/postgres-upgrade) <(bashbrew cat <(./generate-stackbrew-library.sh))
--- /dev/fd/63	2025-08-28 20:09:44.520013765 -0700
+++ /dev/fd/62	2025-08-28 20:09:44.520013765 -0700
@@ -3,15 +3,19 @@
 GitCommit: 6e41d05c59ae7e7cfc073a592e016a169494964b

 Tags: 16-to-17
+Architectures: amd64, arm64v8
 Directory: 16-to-17

 Tags: 15-to-17
+Architectures: amd64, arm64v8
 Directory: 15-to-17

 Tags: 14-to-17
+Architectures: amd64, arm64v8
 Directory: 14-to-17

 Tags: 13-to-17
+Architectures: amd64, arm64v8
 Directory: 13-to-17

 Tags: 15-to-16
```